### PR TITLE
Adding ENV variables to magniv core!

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -137,5 +137,4 @@ dump.json
 .DS_Store
 
 dist/
-setup.py
 instructions.md

--- a/magniv/export/airflow/export_to_airflow.py
+++ b/magniv/export/airflow/export_to_airflow.py
@@ -87,7 +87,7 @@ def _create_docker_image(
     if env_file_path != None:
         env_values_dict = dotenv_values(env_file_path)
         environment_arguments = "\n".join(
-            ["env {}={}\n".format(key, env_values_dict[key]) for key in env_values_dict]
+            ["env {}={}".format(key, env_values_dict[key]) for key in env_values_dict]
         )
     dockerfile = """
 # syntax=docker/dockerfile:1
@@ -99,7 +99,7 @@ RUN pip3 install -r requirements.txt
 
 COPY . .
                 """.format(
-        python_version, environment_arguments, requirements
+        python_version, requirements, environment_arguments
     )
     with open("{}/Dockerfile".format(path), "w") as fo:
         fo.write(dockerfile)

--- a/magniv/export/airflow/export_to_airflow.py
+++ b/magniv/export/airflow/export_to_airflow.py
@@ -3,13 +3,23 @@ import os
 import shutil
 
 import docker
+from dotenv import dotenv_values
 
 from magniv.utils.utils import _create_cloud_build
 
 
-def export_to_airflow(task_list, gcp=False, gcp_project_id=None, gcp_dag_folder=None, callback_hook=None):
+def export_to_airflow(
+    task_list,
+    gcp=False,
+    gcp_project_id=None,
+    gcp_dag_folder=None,
+    callback_hook=None,
+    env_file_path=None,
+):
     dag_template_filename = "dag-template.py"
-    dag_template_directory = "{}/{}".format(os.path.dirname(__file__), dag_template_filename)
+    dag_template_directory = "{}/{}".format(
+        os.path.dirname(__file__), dag_template_filename
+    )
     docker_image_info = []
     for task_info in task_list:
         print("starting task .... ")
@@ -27,6 +37,7 @@ def export_to_airflow(task_list, gcp=False, gcp_project_id=None, gcp_dag_folder=
             task_info["key"],
             gcp=gcp,
             gcp_project_id=gcp_project_id,
+            env_file_path=env_file_path,
         )
         print("docker image created!")
         docker_image_info.append((docker_name, path))
@@ -42,7 +53,9 @@ def export_to_airflow(task_list, gcp=False, gcp_project_id=None, gcp_dag_folder=
                     .replace("functiontoreplace", task_info["name"])
                     .replace(
                         "callbackhooktoreplace",
-                        "'{}'".format(callback_hook) if callback_hook != None else "None",
+                        "'{}'".format(callback_hook)
+                        if callback_hook != None
+                        else "None",
                     )
                     .replace(
                         "successtoreplace",
@@ -59,20 +72,34 @@ def export_to_airflow(task_list, gcp=False, gcp_project_id=None, gcp_dag_folder=
         _create_cloud_build(docker_image_info, gcp_dag_folder)
 
 
-def _create_docker_image(python_version, requirements, key, gcp=False, gcp_project_id=None):
+def _create_docker_image(
+    python_version,
+    requirements,
+    key,
+    gcp=False,
+    gcp_project_id=None,
+    env_file_path=None,
+):
     path = "/".join(requirements.split("/")[:-1])
     if not gcp:
         requirements = "requirements.txt"
+    enviroment_arguments = None
+    if env_file_path != None:
+        env_values_dict = dotenv_values(env_file_path)
+        environment_arguments = "\n".join(
+            ["env {}={}\n".format(key, env_values_dict[key]) for key in env_values_dict]
+        )
     dockerfile = """
 # syntax=docker/dockerfile:1
 
 FROM python:{}
 COPY {} requirements.txt
+{}
 RUN pip3 install -r requirements.txt
 
 COPY . .
                 """.format(
-        python_version, requirements
+        python_version, environment_arguments, requirements
     )
     with open("{}/Dockerfile".format(path), "w") as fo:
         fo.write(dockerfile)

--- a/magniv/export/airflow/export_to_airflow.py
+++ b/magniv/export/airflow/export_to_airflow.py
@@ -87,7 +87,7 @@ def _create_docker_image(
     if env_file_path != None:
         env_values_dict = dotenv_values(env_file_path)
         environment_arguments = "\n".join(
-            ["env {}={}".format(key, env_values_dict[key]) for key in env_values_dict]
+            ["ENV {}={}".format(key, env_values_dict[key]) for key in env_values_dict]
         )
     dockerfile = """
 # syntax=docker/dockerfile:1

--- a/magniv/export/export.py
+++ b/magniv/export/export.py
@@ -2,7 +2,13 @@ from magniv.export.airflow import export_to_airflow
 from magniv.utils.utils import _get_tasks_json
 
 
-def export(gcp=False, gcp_project_id=None, gcp_dag_folder=None, callback_hook=None):
+def export(
+    gcp=False,
+    gcp_project_id=None,
+    gcp_dag_folder=None,
+    callback_hook=None,
+    env_file_path=None,
+):
     task_list = _get_tasks_json("./dump.json")
     export_to_airflow(
         task_list,
@@ -10,4 +16,5 @@ def export(gcp=False, gcp_project_id=None, gcp_dag_folder=None, callback_hook=No
         gcp_project_id=gcp_project_id,
         gcp_dag_folder=gcp_dag_folder,
         callback_hook=callback_hook,
+        env_file_path=env_file_path,
     )

--- a/magniv/scripts/magniv.py
+++ b/magniv/scripts/magniv.py
@@ -20,12 +20,14 @@ def build():
 @click.option("--gcp-project-id")
 @click.option("--gcp-dag-folder")
 @click.option("--callback-hook")
-def export(gcp, gcp_project_id, gcp_dag_folder, callback_hook):
+@click.option("--env-file-path")
+def export(gcp, gcp_project_id, gcp_dag_folder, callback_hook, env_file_path):
     return m_export(
         gcp=gcp,
         gcp_project_id=gcp_project_id,
         gcp_dag_folder=gcp_dag_folder,
         callback_hook=callback_hook,
+        env_file_path=env_file_path,
     )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 apache-airflow==2.3.2
 click==8.0.4
 docker_py==1.10.6
+python-dotenv==0.19.2
 requests==2.27.1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,23 @@
+from setuptools import setup, find_packages
+
+try:
+    with open("proj_description.md", "r", encoding="utf-8") as fh:
+        long_description = fh.read()
+except:
+    long_description = ""
+
+setup(
+    name="magniv",
+    description="Magniv Core Library",
+    author_email="hello@magniv.io",
+    url="https://www.magniv.io",
+    project_urls={"Documentation": "https://docs.magniv.io",},
+    long_description=long_description,
+    long_description_content_type="text/markdown",
+    version="0.1.34",
+    py_modules=["magniv"],
+    packages=find_packages(),
+    install_requires=["Click", "docker"],
+    entry_points={"console_scripts": ["magniv-cli = magniv.scripts.magniv:cli",],},
+    include_package_data=True,
+)


### PR DESCRIPTION
# Description

Adding the ability to pass a environment file to `magniv-cli export`
This will allow us to build out a env variables UI on the hosted version of magniv so people do not need to hard code in their tokens.

Majority of the change exists in the `magniv/export/export.py` file.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works