### PR TITLE
Adding timeout option for KubernetesPodOperator

### DIFF
--- a/magniv/export/airflow/dag-template.py
+++ b/magniv/export/airflow/dag-template.py
@@ -43,6 +43,7 @@ with dag:
         namespace="default",
         image=imagetoreplace,
         cmds=["magniv-cli", "run", "filetoreplace", "functiontoreplace"],
+        startup_timeout_seconds=startuptoreplace,
         on_failure_callback=failuretoreplace,
         on_success_callback=successtoreplace,
     )

--- a/magniv/export/airflow/export_to_airflow.py
+++ b/magniv/export/airflow/export_to_airflow.py
@@ -62,7 +62,7 @@ def export_to_airflow(
                         "failuretoreplace",
                         "_on_failure" if callback_hook != None else "None",
                     )
-                    .replace("startuptoreplace", kubernetes_startup_timeout)
+                    .replace("startuptoreplace", str(kubernetes_startup_timeout))
                 )
                 print(line, end="")
         print("dag created!")

--- a/magniv/export/airflow/export_to_airflow.py
+++ b/magniv/export/airflow/export_to_airflow.py
@@ -14,6 +14,7 @@ def export_to_airflow(
     gcp_project_id=None,
     gcp_dag_folder=None,
     callback_hook=None,
+    kubernetes_startup_timeout=None,
     env_file_path=None,
 ):
     dag_template_filename = "dag-template.py"
@@ -61,6 +62,7 @@ def export_to_airflow(
                         "failuretoreplace",
                         "_on_failure" if callback_hook != None else "None",
                     )
+                    .replace("startuptoreplace", kubernetes_startup_timeout)
                 )
                 print(line, end="")
         print("dag created!")

--- a/magniv/export/export.py
+++ b/magniv/export/export.py
@@ -7,6 +7,7 @@ def export(
     gcp_project_id=None,
     gcp_dag_folder=None,
     callback_hook=None,
+    kubernetes_startup_timeout=None,
     env_file_path=None,
 ):
     task_list = _get_tasks_json("./dump.json")
@@ -16,5 +17,6 @@ def export(
         gcp_project_id=gcp_project_id,
         gcp_dag_folder=gcp_dag_folder,
         callback_hook=callback_hook,
+        kubernetes_startup_timeout=kubernetes_startup_timeout,
         env_file_path=env_file_path,
     )

--- a/magniv/scripts/magniv.py
+++ b/magniv/scripts/magniv.py
@@ -20,8 +20,16 @@ def build():
 @click.option("--gcp-project-id")
 @click.option("--gcp-dag-folder")
 @click.option("--callback-hook")
+@click.option("--kubernetes-startup-timeout", default=120)
 @click.option("--env-file-path")
-def export(gcp, gcp_project_id, gcp_dag_folder, callback_hook, env_file_path):
+def export(
+    gcp,
+    gcp_project_id,
+    gcp_dag_folder,
+    callback_hook,
+    kubernetes_startup_timeout,
+    env_file_path,
+):
     return m_export(
         gcp=gcp,
         gcp_project_id=gcp_project_id,

--- a/magniv/scripts/magniv.py
+++ b/magniv/scripts/magniv.py
@@ -35,6 +35,7 @@ def export(
         gcp_project_id=gcp_project_id,
         gcp_dag_folder=gcp_dag_folder,
         callback_hook=callback_hook,
+        kubernetes_startup_timeout=kubernetes_startup_timeout,
         env_file_path=env_file_path,
     )
 


### PR DESCRIPTION
We are having issues where on GCP the podoperator timeout before the pod is actually created. Default startup timeout on the operator is 120 seconds and based on my tests it seems like sometimes GCP needs more time than that.

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works
