### PR TITLE
Only parse decorators based on imports on a file basis

### DIFF
--- a/magniv/build/build.py
+++ b/magniv/build/build.py
@@ -56,7 +56,7 @@ def _get_decorator_name(func):
     Returns:
       The name of the decorator.
     """
-    if isinstance(func, ast.Name) and hasattr(func, "id"):
+    if hasattr(func, "id"):
         return func.id
     if isinstance(func, ast.Attribute) and hasattr(func, "value") and hasattr(func, "attr"):
         return ".".join([_get_decorator_name(func.value), func.attr])

--- a/magniv/build/build.py
+++ b/magniv/build/build.py
@@ -28,29 +28,72 @@ def _get_owner(root):
     return "local"
 
 
+def _get_ast_alias(names: List, key: str):
+    matching_name = next((i for i in names if i.name == key), None)
+    if not matching_name:
+        return None
+    return matching_name.asname if matching_name.asname else matching_name.name
+
+
+def _get_decorator_name(func):
+    if isinstance(func, ast.Name):
+        if hasattr(func, "id"):
+            return func.id
+    if isinstance(func, ast.Attribute):
+        if hasattr(func, "value") and hasattr(func, "attr"):
+            return ".".join([_get_decorator_name(func.value), func.attr])
+    return ""
+
+
 def get_decorated_nodes(parsed_ast: ast.AST) -> List:
     """
-    It returns a list of all function and async function definitions in the AST that have at least one
-    decorator
+    It returns decorator nodes and decorator aliases.
 
     Args:
       parsed_ast (ast.AST): The parsed AST of the file.
 
     Returns:
       A list of nodes that are either a FunctionDef or AsyncFunctionDef and have a decorator_list.
+      A list of aliases that can be used for Magniv task decorators.
     """
-    return [
-        node
-        for node in ast.walk(parsed_ast)
-        if (
-            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
-            and len(node.decorator_list) > 0
-        )
-    ]
+
+    decorator_aliases = []
+    decorated_nodes = []
+    for node in ast.walk(parsed_ast):
+        # Add decorated functions
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) and len(node.decorator_list) > 0:
+            decorated_nodes.append(node)
+            continue
+
+        # Add possible decorator aliases
+        if isinstance(node, ast.Import):
+            import_variants = [   
+                # import magniv --- @magniv.core.task
+                {"import": "magniv", "decorator_suffix": ".core.task"}, 
+                # import magniv.core --- @magniv.core.task
+                {"import": "magniv.core", "decorator_suffix": ".task"}
+            ]
+            for variant in import_variants:
+                alias = _get_ast_alias(node.names, variant["import"])
+                if alias:
+                    decorator_aliases.append(alias + variant["decorator_suffix"])
+        elif isinstance(node, ast.ImportFrom):
+            if node.module == 'magniv.core':
+                # from magniv.core import task --- @task
+                alias = _get_ast_alias(node.names, "task")
+                if alias:
+                    decorator_aliases.append(alias)
+            elif node.module == 'magniv':
+                # from magniv import core --- @core.task
+                alias = _get_ast_alias(node.names, "core")
+                if alias:
+                    decorator_aliases.append(alias + ".task")
+
+    return decorated_nodes, decorator_aliases
 
 
 def get_magniv_tasks(
-    filepath: str, decorated_nodes: List, root: str, req: str, used_keys: Dict
+    filepath: str, decorated_nodes: List, decorator_aliases: List, root: str, req: str, used_keys: Dict
 ) -> Tuple[List, Dict]:
     """
     It returns all Magniv decorated tasks from a list of python functions that are decorated
@@ -75,12 +118,11 @@ def get_magniv_tasks(
             "description": None,
         }
         for decorator in node.decorator_list:
-            if (
-                not isinstance(decorator, ast.Name)
-                and hasattr(decorator, "func")
-                and hasattr(decorator.func, "id")
-                and decorator.func.id == "task"
-            ):
+            if hasattr(decorator, "func"):
+                decorator_name = _get_decorator_name(decorator.func)
+                if decorator_name not in decorator_aliases:
+                    continue
+
                 decorator_values = {kw.arg: kw.value.value for kw in decorator.keywords}
                 info = {**core_values, **decorator_values}
                 if missing_reqs := list({"schedule"} - set(info)):
@@ -95,6 +137,7 @@ def get_magniv_tasks(
                     )
                 used_keys[info["key"]] = filepath
                 tasks.append(info)
+
     return tasks
 
 
@@ -150,11 +193,12 @@ def get_task_list(
     for fileinfo in task_files:
         with open(fileinfo["filepath"]) as f:
             parsed_ast = ast.parse(f.read())
-            decorated_nodes = get_decorated_nodes(parsed_ast)
+            decorated_nodes, decorator_aliases = get_decorated_nodes(parsed_ast)
             tasks_list.extend(
                 get_magniv_tasks(
                     fileinfo["filepath"],
                     decorated_nodes,
+                    decorator_aliases,
                     root=task_folder,
                     req=fileinfo["req"],
                     used_keys=used_keys,

--- a/magniv/build/build.py
+++ b/magniv/build/build.py
@@ -214,7 +214,10 @@ def get_task_list(
         used_keys = {}
     for fileinfo in task_files:
         with open(fileinfo["filepath"]) as f:
-            parsed_ast = ast.parse(f.read())
+            try:
+                parsed_ast = ast.parse(f.read())
+            except UnicodeDecodeError as e:
+                continue
             decorated_nodes, decorator_aliases = get_decorated_nodes(parsed_ast)
             tasks_list.extend(
                 get_magniv_tasks(

--- a/tests/README.md
+++ b/tests/README.md
@@ -44,5 +44,10 @@ build.py:
             - saves dump.json to expected path
             - throws oserror if no file with decorated task is found
             - throws oserror if dir specified dir not found
-	    - multiple tasks within one file
+            - multiple tasks within one file
+        test_build_imports.py
+            - import magniv
+            - from magniv.core import task
+            - from magniv import core as ___
+
 ```

--- a/tests/unit_tests/test_build.py
+++ b/tests/unit_tests/test_build.py
@@ -64,7 +64,7 @@ class TestBuild:
         `get_decorated_nodes` returns a list of all the decorated functions in a Python file
         """
         parsed_ast, filepath = self.get_ast(file)
-        decorated_nodes = get_decorated_nodes(parsed_ast)
+        decorated_nodes, _ = get_decorated_nodes(parsed_ast)
         self._extracted_from_test_get_decorated_nodes(
             decorated_nodes, 0, "hello_world", "@hourly", "goodbye_world_1"
         )
@@ -78,11 +78,12 @@ class TestBuild:
         dictionaries containing the information about each task
         """
         parsed_ast, filepath = self.get_ast(file)
-        decorated_nodes = get_decorated_nodes(parsed_ast)
+        decorated_nodes, decorator_aliases = get_decorated_nodes(parsed_ast)
         used_keys = {}
         tasks = get_magniv_tasks(
             filepath,
             decorated_nodes,
+            decorator_aliases,
             root="tests/unit_tests",
             req="requirements.txt",
             used_keys=used_keys,

--- a/tests/unit_tests/test_build_imports.py
+++ b/tests/unit_tests/test_build_imports.py
@@ -1,19 +1,7 @@
-import ast
-import os
-from typing import Union
-
 import pytest
 
+from magniv.build.build import get_decorated_nodes
 from tests.unit_tests.test_build import TestBuild
-
-from magniv.build.build import (
-    build,
-    get_decorated_nodes,
-    get_magniv_tasks,
-    get_task_files,
-    get_task_list,
-    save_tasks,
-)
 
 TEST_FILE = """from datetime import datetime
 
@@ -47,11 +35,34 @@ if __name__ == "__main__":
 class TestBuild(TestBuild):
     @pytest.fixture
     def file(self, tmpdir):
+        """
+        It creates a directory called tasks, creates a file called main.py in that directory, and writes
+        the contents of the TEST_FILE variable to that file. It then creates a file called
+        requirements.txt in the tasks directory and writes the word magniv to it. Finally, it returns
+        the path to the tasks directory
+
+        Args:
+          tmpdir: This is a pytest fixture that creates a temporary directory for us to use.
+
+        Returns:
+          The path to the directory where the file is located.
+        """
         tmpdir.mkdir("tasks").join("main.py").write(TEST_FILE)
         tmpdir.join("tasks/requirements.txt").write("magniv")
         return str(tmpdir.join("tasks"))
 
     def _extracted_from_test_get_decorated_nodes(self, decorated_nodes, arg1, arg2, arg3, arg4):
+        """
+        A function that checks if the name of the node is the same as the name of the function, and if
+        the decorator list has the same keywords as the function.
+
+        Args:
+          decorated_nodes: the list of nodes that have been decorated
+          arg1: The index of the decorated node in the list of decorated nodes.
+          arg2: the name of the function
+          arg3: the schedule
+          arg4: the name of the function
+        """
         assert decorated_nodes[arg1].name == arg2
         assert decorated_nodes[arg1].decorator_list[0].keywords[0].arg == "schedule"
         assert decorated_nodes[arg1].decorator_list[0].keywords[0].value.s == arg3

--- a/tests/unit_tests/test_build_imports.py
+++ b/tests/unit_tests/test_build_imports.py
@@ -1,0 +1,74 @@
+import ast
+import os
+from typing import Union
+
+import pytest
+
+from tests.unit_tests.test_build import TestBuild
+
+from magniv.build.build import (
+    build,
+    get_decorated_nodes,
+    get_magniv_tasks,
+    get_task_files,
+    get_task_list,
+    save_tasks,
+)
+
+TEST_FILE = """from datetime import datetime
+
+import magniv
+from magniv.core import task
+from magniv import core as mc
+
+
+@magniv.core.task(schedule="@hourly", description="Hello world, printing the time", key="goodbye_world_1")
+def hello_world():
+    print(f"Hello world, the time is {datetime.now()}")
+
+@task(schedule="@daily", description="Hello world, printing a second time", key="goodbye_world_2")
+def hello_world_2():
+    print(f"Hello world, the time is {datetime.now()}")
+
+@mc.task(schedule="@daily", description="Hello world, printing a third time", key="goodbye_world_3")
+def hello_world_3():
+    print(f"Hello world, the time is {datetime.now()}")
+
+
+def dummy_task():
+    print("This is a dummy task")
+    return True
+
+if __name__ == "__main__":
+    hello_world()
+"""
+
+
+class TestBuild(TestBuild):
+    @pytest.fixture
+    def file(self, tmpdir):
+        tmpdir.mkdir("tasks").join("main.py").write(TEST_FILE)
+        tmpdir.join("tasks/requirements.txt").write("magniv")
+        return str(tmpdir.join("tasks"))
+
+    def _extracted_from_test_get_decorated_nodes(self, decorated_nodes, arg1, arg2, arg3, arg4):
+        assert decorated_nodes[arg1].name == arg2
+        assert decorated_nodes[arg1].decorator_list[0].keywords[0].arg == "schedule"
+        assert decorated_nodes[arg1].decorator_list[0].keywords[0].value.s == arg3
+        assert decorated_nodes[arg1].decorator_list[0].keywords[2].value.s == arg4
+
+    def test_get_decorated_nodes(self, file):
+        """
+        `get_decorated_nodes` returns a list of all the decorated functions in a Python file
+        """
+        parsed_ast, filepath = self.get_ast(file)
+        decorated_nodes, _ = get_decorated_nodes(parsed_ast)
+        self._extracted_from_test_get_decorated_nodes(
+            decorated_nodes, 0, "hello_world", "@hourly", "goodbye_world_1"
+        )
+        self._extracted_from_test_get_decorated_nodes(
+            decorated_nodes, 1, "hello_world_2", "@daily", "goodbye_world_2"
+        )
+        self._extracted_from_test_get_decorated_nodes(
+            decorated_nodes, 2, "hello_world_3", "@daily", "goodbye_world_3"
+        )


### PR DESCRIPTION
# Description

Fix the issue where we were only checking for `@task` decorators. Users should be able to import magniv however they want. Right now we will not catch anything other than `@task`. Here are the cases this PR addresses:

```
import magniv --- @magniv.core.task
import magniv.core --- @magniv.core.task 
from magniv.core import task --- @task 
from magniv import core --- @core.task 
```

In addition, this fixes the issue where virtual env garbage in `/tasks` folder breaks the build. Imagine users can now have both Airflow tasks and Magniv tasks in one file (not sure why they would ever want this though)

The only remaining edgecase is the one where a user overwrites the decorator with another import. This should not be done anyway (only by mistake), so we will ignore here.

# Checklist:

- [X] I have performed a self-review of my own code
- [ ] My code follows the style guidelines of this project
- [X] I have commented my code in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works
