### PR TITLE
Enable custom resources via task decorator

### DIFF
--- a/magniv/build/build.py
+++ b/magniv/build/build.py
@@ -147,6 +147,7 @@ def get_magniv_tasks(
                 decorator_name = _get_decorator_name(decorator.func)
                 if decorator_name not in decorator_aliases:
                     continue
+
                 constructed_decorator_values = {}
                 for kw in decorator.keywords:
                     if isinstance(kw.value, ast.Dict):
@@ -168,6 +169,7 @@ def get_magniv_tasks(
                     raise Exception(
                         f"Building the task {node.name} in {core_values['location']} on line {core_values['line_number']} raised the following {type(e).__name__}: {e}"
                     )
+
                 info = {**core_values, **decorator_values}
                 if missing_reqs := list({"schedule"} - set(info)):
                     raise ValueError(

--- a/magniv/build/build.py
+++ b/magniv/build/build.py
@@ -147,10 +147,17 @@ def get_magniv_tasks(
                 decorator_name = _get_decorator_name(decorator.func)
                 if decorator_name not in decorator_aliases:
                     continue
-
-                constructed_decorator_values = {
-                    kw.arg: kw.value.value for kw in decorator.keywords
-                }
+                constructed_decorator_values = {}
+                for kw in constructed_decorator_values.keywords:
+                    if isinstance(kw.value, ast.Dict):
+                        constructed_decorator_values[kw.arg] = dict(
+                            zip(
+                                [key.value for key in kw.value.keys],
+                                [val.value for val in kw.value.values],
+                            )
+                        )
+                    else:
+                        constructed_decorator_values[kw.arg] = kw.value.value
                 # Verify that the arugments are correct
                 try:
                     dummy_function = lambda x: None
@@ -161,7 +168,6 @@ def get_magniv_tasks(
                     raise Exception(
                         f"Building the task {node.name} in {core_values['location']} on line {core_values['line_number']} raised the following {type(e).__name__}: {e}"
                     )
-
                 info = {**core_values, **decorator_values}
                 if missing_reqs := list({"schedule"} - set(info)):
                     raise ValueError(

--- a/magniv/build/build.py
+++ b/magniv/build/build.py
@@ -148,7 +148,7 @@ def get_magniv_tasks(
                 if decorator_name not in decorator_aliases:
                     continue
                 constructed_decorator_values = {}
-                for kw in constructed_decorator_values.keywords:
+                for kw in decorator.keywords:
                     if isinstance(kw.value, ast.Dict):
                         constructed_decorator_values[kw.arg] = dict(
                             zip(

--- a/magniv/core/task.py
+++ b/magniv/core/task.py
@@ -43,6 +43,7 @@ class Task:
     def as_dict(self) -> dict:
         return {
             "schedule": self.schedule,
+            "resources": self.resources,
             "description": self.description,
             "name": self.name,
             "key": self.key,
@@ -82,9 +83,21 @@ class Task:
 
     def _make_valid_resources(self, resources) -> Dict[str, str]:
         """
-        TODO: add functionality to sanitize inputs for resource requests
+        Takes in a resources dictionary with generic parameters and converts it to the appropriate syntax
+        for our infrastructure
+        #TODO: enforce reasonable limits for quantity of resources
+
+        :param key: The generic resources dict from the task decorator
+        :return: A dict with correct syntax
         """
-        return resources
+        clean_dict = {}
+
+        if "cpu" in resources.keys():
+            clean_dict["limit_cpu"] = resources["cpu"]
+        if "memory" in resources.keys():
+            clean_dict["limit_memory"] = resources["memory"]
+
+        return clean_dict
 
 
 def task(_func=None, *, schedule=None, resources=None, description=None, key=None) -> Callable:

--- a/magniv/core/task.py
+++ b/magniv/core/task.py
@@ -1,6 +1,6 @@
 import re
 from functools import update_wrapper
-from typing import Callable
+from typing import Callable, Dict
 
 from croniter import CroniterBadCronError, CroniterBadDateError, CroniterNotAlphaError, croniter
 
@@ -13,18 +13,20 @@ class Task:
 
     :param function: the function that is being decorated
     :param schedule: the cron schedule that this function will be scheduled with
+    :param resources: the cpu and memory requirements for this function
     :param description: description of the function, to be used for the auto generated documentation
     :param key: the unique key that will reference the function, default is the function of the name
     """
 
     KEY_PATTERN = r"^[\w\-.]+$"
 
-    def __init__(self, function, schedule=None, description=None, key=None) -> None:
+    def __init__(self, function, schedule=None, resources=None, description=None, key=None) -> None:
         if schedule is None:
             raise ValueError("schedule must be provided")
         if not self._is_valid_schedule(schedule):
             raise ValueError(f"{schedule} is not a valid cron schedule")
         self.schedule = schedule
+        self.resources = self._make_valid_resources(resources)
         self.description = description
         self.function = function
         self.name = function.__name__
@@ -78,8 +80,14 @@ class Task:
         """
         return bool(re.match(Task.KEY_PATTERN, key))
 
+    def _make_valid_resources(self, resources) -> Dict[str, str]:
+        """
+        TODO: add functionality to sanitize inputs for resource requests
+        """
+        return resources
 
-def task(_func=None, *, schedule=None, description=None, key=None) -> Callable:
+
+def task(_func=None, *, schedule=None, resources=None, description=None, key=None) -> Callable:
     """
     If they pass in a function, then we raise an error. If they dont pass in a function, then we return
     a wrapper function that takes a function as an argument
@@ -87,6 +95,7 @@ def task(_func=None, *, schedule=None, description=None, key=None) -> Callable:
     :param _func: This is the function that is being wrapped
     :param schedule: This is the schedule that the task will run on. It can be a cron string, or a
     datetime.timedelta object
+    :param resources: the cpu and memory requirements for this function
     :param description: A description of the task
     :param key: This is the name of the task key. It is used to identify the task in the database
     :return: A function that takes in a function and returns a task instance.
@@ -96,6 +105,6 @@ def task(_func=None, *, schedule=None, description=None, key=None) -> Callable:
         raise ValueError("You must use arguments with magniv, it can not be called alone")
 
     def wrapper(function):
-        return Task(function, schedule=schedule, description=description, key=key)
+        return Task(function, schedule=schedule, resources=None, description=description, key=key)
 
     return wrapper

--- a/magniv/core/task.py
+++ b/magniv/core/task.py
@@ -92,6 +92,8 @@ class Task:
         """
         clean_dict = {}
 
+        if resources is None:
+            return resources
         if "cpu" in resources.keys():
             clean_dict["limit_cpu"] = resources["cpu"]
         if "memory" in resources.keys():

--- a/magniv/export/airflow/dag-template.py
+++ b/magniv/export/airflow/dag-template.py
@@ -58,6 +58,7 @@ with dag:
         namespace="default",
         image=imagetoreplace,
         cmds=["magniv-cli", "run", "filetoreplace", "functiontoreplace"],
+        resources=resourcesdicttoreplace,
         startup_timeout_seconds=startuptoreplace,
         on_failure_callback=failuretoreplace,
         on_success_callback=successtoreplace,

--- a/magniv/export/airflow/export_to_airflow.py
+++ b/magniv/export/airflow/export_to_airflow.py
@@ -65,6 +65,12 @@ def export_to_airflow(
                     .replace("filetoreplace", task_info["location"])
                     .replace("functiontoreplace", task_info["name"])
                     .replace(
+                        "resourcesdicttoreplace",
+                        str(task_info["resources"])
+                        if "resources" in task_info.keys()
+                        else "None",
+                    )
+                    .replace(
                         "callbackhooktoreplace",
                         f"'{callback_hook}'" if callback_hook is not None else "None",
                     )


### PR DESCRIPTION
# Description

Adds capability to pass `resources` dictionary through the `task` decorator to define custom hardware requirements for a task. Specifically, allows for custom:
- cpu
- memory

`build` expects the decorator to contain generic names for these resources, as per [the docs](https://github.com/MagnivOrg/magniv-docs/pull/3)

These are then converted to use the appropriate syntax for GKE autopilot + airflow

Also adds test coverage for this feature; pytest passing:
<img width="734" alt="image" src="https://user-images.githubusercontent.com/2421621/186934411-b28d1d00-5a1a-463c-9efb-cb534e05d078.png">

Future considerations:
- sanitize resource inputs further to limit quantity of resources requested
- enable GPU

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
