### PR TITLE
Enable webhook trigger

### DIFF
--- a/magniv/core/task.py
+++ b/magniv/core/task.py
@@ -21,14 +21,14 @@ class Task:
     KEY_PATTERN = r"^[\w\-.]+$"
 
     def __init__(
-        self, function, schedule=None, webhook_enabled=False, resources=None, description=None, key=None
+        self, function, schedule=None, enable_webhook=False, resources=None, description=None, key=None
     ) -> None:
         if schedule is None:
             raise ValueError("schedule must be provided")
         if not self._is_valid_schedule(schedule):
             raise ValueError(f"{schedule} is not a valid cron schedule")
         self.schedule = schedule
-        self.webhook_enabled = webhook_enabled
+        self.enable_webhook = enable_webhook
         self.resources = self._make_valid_resources(resources)
         self.description = description
         self.function = function
@@ -46,7 +46,7 @@ class Task:
     def as_dict(self) -> dict:
         return {
             "schedule": self.schedule,
-            "webhook_enabled": self.webhook_enabled,
+            "enable_webhook": self.enable_webhook,
             "resources": self.resources,
             "description": self.description,
             "name": self.name,
@@ -110,7 +110,7 @@ class Task:
         return clean_dict
 
 
-def task(_func=None, *, schedule=None, webhook_enabled=False, resources=None, description=None, key=None) -> Callable:
+def task(_func=None, *, schedule=None, enable_webhook=False, resources=None, description=None, key=None) -> Callable:
     """
     If they pass in a function, then we raise an error. If they dont pass in a function, then we return
     a wrapper function that takes a function as an argument
@@ -128,6 +128,6 @@ def task(_func=None, *, schedule=None, webhook_enabled=False, resources=None, de
         raise ValueError("You must use arguments with magniv, it can not be called alone")
 
     def wrapper(function):
-        return Task(function, schedule=schedule, webhook_enabled=webhook_enabled, resources=resources, description=description, key=key)
+        return Task(function, schedule=schedule, enable_webhook=enable_webhook, resources=resources, description=description, key=key)
 
     return wrapper

--- a/magniv/core/task.py
+++ b/magniv/core/task.py
@@ -21,13 +21,14 @@ class Task:
     KEY_PATTERN = r"^[\w\-.]+$"
 
     def __init__(
-        self, function, schedule=None, resources=None, description=None, key=None
+        self, function, schedule=None, webhook_enabled=False, resources=None, description=None, key=None
     ) -> None:
         if schedule is None:
             raise ValueError("schedule must be provided")
         if not self._is_valid_schedule(schedule):
             raise ValueError(f"{schedule} is not a valid cron schedule")
         self.schedule = schedule
+        self.webhook_enabled = webhook_enabled
         self.resources = self._make_valid_resources(resources)
         self.description = description
         self.function = function
@@ -45,6 +46,7 @@ class Task:
     def as_dict(self) -> dict:
         return {
             "schedule": self.schedule,
+            "webhook_enabled": self.webhook_enabled,
             "resources": self.resources,
             "description": self.description,
             "name": self.name,
@@ -108,7 +110,7 @@ class Task:
         return clean_dict
 
 
-def task(_func=None, *, schedule=None, resources=None, description=None, key=None) -> Callable:
+def task(_func=None, *, schedule=None, webhook_enabled=False, resources=None, description=None, key=None) -> Callable:
     """
     If they pass in a function, then we raise an error. If they dont pass in a function, then we return
     a wrapper function that takes a function as an argument
@@ -126,6 +128,6 @@ def task(_func=None, *, schedule=None, resources=None, description=None, key=Non
         raise ValueError("You must use arguments with magniv, it can not be called alone")
 
     def wrapper(function):
-        return Task(function, schedule=schedule, resources=None, description=description, key=key)
+        return Task(function, schedule=schedule, webhook_enabled=webhook_enabled, resources=resources, description=description, key=key)
 
     return wrapper

--- a/magniv/core/task.py
+++ b/magniv/core/task.py
@@ -21,14 +21,14 @@ class Task:
     KEY_PATTERN = r"^[\w\-.]+$"
 
     def __init__(
-        self, function, schedule=None, enable_webhook=False, resources=None, description=None, key=None
+        self, function, schedule=None, enable_webhook_trigger=False, resources=None, description=None, key=None
     ) -> None:
         if schedule is None:
             raise ValueError("schedule must be provided")
         if not self._is_valid_schedule(schedule):
             raise ValueError(f"{schedule} is not a valid cron schedule")
         self.schedule = schedule
-        self.enable_webhook = enable_webhook
+        self.enable_webhook_trigger = enable_webhook_trigger
         self.resources = self._make_valid_resources(resources)
         self.description = description
         self.function = function
@@ -46,7 +46,7 @@ class Task:
     def as_dict(self) -> dict:
         return {
             "schedule": self.schedule,
-            "enable_webhook": self.enable_webhook,
+            "enable_webhook_trigger": self.enable_webhook_trigger,
             "resources": self.resources,
             "description": self.description,
             "name": self.name,
@@ -110,7 +110,7 @@ class Task:
         return clean_dict
 
 
-def task(_func=None, *, schedule=None, enable_webhook=False, resources=None, description=None, key=None) -> Callable:
+def task(_func=None, *, schedule=None, enable_webhook_trigger=False, resources=None, description=None, key=None) -> Callable:
     """
     If they pass in a function, then we raise an error. If they dont pass in a function, then we return
     a wrapper function that takes a function as an argument
@@ -128,6 +128,6 @@ def task(_func=None, *, schedule=None, enable_webhook=False, resources=None, des
         raise ValueError("You must use arguments with magniv, it can not be called alone")
 
     def wrapper(function):
-        return Task(function, schedule=schedule, enable_webhook=enable_webhook, resources=resources, description=description, key=key)
+        return Task(function, schedule=schedule, enable_webhook_trigger=enable_webhook_trigger, resources=resources, description=description, key=key)
 
     return wrapper

--- a/magniv/core/task.py
+++ b/magniv/core/task.py
@@ -2,12 +2,7 @@ import re
 from functools import update_wrapper
 from typing import Callable, Dict
 
-from croniter import (
-    CroniterBadCronError,
-    CroniterBadDateError,
-    CroniterNotAlphaError,
-    croniter,
-)
+from croniter import CroniterBadCronError, CroniterBadDateError, CroniterNotAlphaError, croniter
 
 
 class Task:

--- a/magniv/core/task.py
+++ b/magniv/core/task.py
@@ -145,9 +145,7 @@ def task(
     """
     if _func is not None:  # this means they did not pass in any arguments like @magniv
         # The reason we do this here is bc in the case they dont pass arguments we dont need the extra wrapper below.
-        raise ValueError(
-            "You must use arguments with magniv, it can not be called alone"
-        )
+        raise ValueError("You must use arguments with magniv, it can not be called alone")
 
     def wrapper(function):
         return Task(

--- a/magniv/core/task.py
+++ b/magniv/core/task.py
@@ -2,7 +2,12 @@ import re
 from functools import update_wrapper
 from typing import Callable, Dict
 
-from croniter import CroniterBadCronError, CroniterBadDateError, CroniterNotAlphaError, croniter
+from croniter import (
+    CroniterBadCronError,
+    CroniterBadDateError,
+    CroniterNotAlphaError,
+    croniter,
+)
 
 
 class Task:
@@ -21,7 +26,13 @@ class Task:
     KEY_PATTERN = r"^[\w\-.]+$"
 
     def __init__(
-        self, function, schedule=None, enable_webhook_trigger=False, resources=None, description=None, key=None
+        self,
+        function,
+        schedule=None,
+        enable_webhook_trigger=False,
+        resources=None,
+        description=None,
+        key=None,
     ) -> None:
         if schedule is None:
             raise ValueError("schedule must be provided")
@@ -110,7 +121,15 @@ class Task:
         return clean_dict
 
 
-def task(_func=None, *, schedule=None, enable_webhook_trigger=False, resources=None, description=None, key=None) -> Callable:
+def task(
+    _func=None,
+    *,
+    schedule=None,
+    enable_webhook_trigger=False,
+    resources=None,
+    description=None,
+    key=None,
+) -> Callable:
     """
     If they pass in a function, then we raise an error. If they dont pass in a function, then we return
     a wrapper function that takes a function as an argument
@@ -126,9 +145,18 @@ def task(_func=None, *, schedule=None, enable_webhook_trigger=False, resources=N
     """
     if _func is not None:  # this means they did not pass in any arguments like @magniv
         # The reason we do this here is bc in the case they dont pass arguments we dont need the extra wrapper below.
-        raise ValueError("You must use arguments with magniv, it can not be called alone")
+        raise ValueError(
+            "You must use arguments with magniv, it can not be called alone"
+        )
 
     def wrapper(function):
-        return Task(function, schedule=schedule, enable_webhook_trigger=enable_webhook_trigger, resources=resources, description=description, key=key)
+        return Task(
+            function,
+            schedule=schedule,
+            enable_webhook_trigger=enable_webhook_trigger,
+            resources=resources,
+            description=description,
+            key=key,
+        )
 
     return wrapper

--- a/magniv/core/task.py
+++ b/magniv/core/task.py
@@ -118,7 +118,8 @@ def task(_func=None, *, schedule=None, enable_webhook_trigger=False, resources=N
     :param _func: This is the function that is being wrapped
     :param schedule: This is the schedule that the task will run on. It can be a cron string, or a
     datetime.timedelta object
-    :param resources: the cpu and memory requirements for this function
+    :param enable_webhook_trigger: Specifices whether this task can be triggered via webhook (see dashboard for webhook URL)
+    :param resources: The cpu and memory requirements for this function
     :param description: A description of the task
     :param key: This is the name of the task key. It is used to identify the task in the database
     :return: A function that takes in a function and returns a task instance.

--- a/tests/unit_tests/test_build.py
+++ b/tests/unit_tests/test_build.py
@@ -30,6 +30,10 @@ def hello_world_2():
 def resourceful_valid():
     print("using custom resources!")
 
+@task(schedule="@daily", enable_webhook_trigger=True)
+def playing_webhooky():
+    print("I'M TRIGGERED")
+
 def dummy_task():
     print("This is a dummy task")
     return True
@@ -184,8 +188,8 @@ class TestBuild:
                     "limit_memory": "3Gi",
                 }
 
-    def test_task_ignores_invalid_custom_resources(self, file):
+    def test_task_builds_with_webhook_trigger_enabled(self, file):
         task_list = get_task_list([{"filepath": f"{file}/main.py", "req": None}])
         for task in task_list:
-            if task["name"] == "resourceful_invalid":
-                assert not task["resources"]
+            if task["name"] == "playing_webhooky":
+                assert task["enable_webhook_trigger"]


### PR DESCRIPTION
# Description

Adds a `enable_webhook_trigger` field to the decorator to support running tasks programmatically via webhook

Related `magniv-api` PR: https://github.com/MagnivOrg/magniv-api/pull/41

OTHER ITEMS:
- removes test rendered useless by https://github.com/MagnivOrg/magniv-core/commit/e5c551f2abcadaca62687596a6772b1fea414586
- changes default https://github.com/MagnivOrg/magniv-core/blob/f6117a9a720b988d84d758267accf02a3552aa31/magniv/core/task.py#L129

# Checklist:

- [x] I have performed a self-review of my own code
- [x] My code follows the style guidelines of this project
- [x] I have commented my code in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

![image](https://user-images.githubusercontent.com/2421621/189367954-3c8931a7-75a2-4ff5-b39a-3396b42536d5.png)
